### PR TITLE
Make the vendor products be shown from api instead of array in the home until the allProducts api is ready it will show vendor products

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,87 +18,87 @@ const App = () => {
 
   const userLogin = {isLogin, setLogin, userData, setUserData};
   
-  const products = [{
-    type: "laptop",
-    description: "Details\n\
-                        Lenovo ThinkPad E14 Gen2\n\
-                        Intel Core i7-1165G7\n\
-                        512GB SSD\n\
-                        8GB Ram\n\
-                        Graphics NVIDIA GeForce MX450 2GB\n\
-                        Display 14 FHD (1920x1080) IPS 250nits\n\
-                        Color  black",
-    model: "Lenovo ThinkPad E14 Gen2",
-    price: "$1,375",
-    stock: "12",
-    images: ["./prouducts_photo/Laptops/LENOVO THINKPAD E14/1.png",
-      "./prouducts_photo/Laptops/LENOVO THINKPAD E14/2.png",
-      "./prouducts_photo/Laptops/LENOVO THINKPAD E14/3.png",
-      "./prouducts_photo/Laptops/LENOVO THINKPAD E14/4.png",
-      "./prouducts_photo/Laptops/LENOVO THINKPAD E14/5.png"],
-    stars: "4.8",
-  },
-    {
-      type: "laptop",
-      description: "Details\n\
-                        Lenovo Ideapad Gaming 3\n\
-                        Core I7-12650H\n\
-                        16G Ram\n\
-                        512 NVME\n\
-                        VGA Nvidia 4G RTX 3050Ti\n\
-                        15.6 FHD 165Hz\n\
-                        Color gray",
-      model: "Lenovo Ideapad Gaming 3",
-      price: "$1,482",
-      stock: "5",
-      images: ["./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/1.png",
-        "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/2.png",
-        "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/3.png",
-        "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/4.png",
-        "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/5.png"],
-      stars: "3",
-    },
-    {
-      type: "laptop",
-      description: "Details\n\
-                        HP Probook 450 G9\n\
-                        Core I5 - 1235U\n\
-                        15.6 HD\n\
-                        8GB\n\
-                        512GB SSD\n\
-                        MX570 2GB - DOS\n\
-                        color Silver Aluminum",
-      model: "HP Probook 450",
-      price: "$1,335",
-      stock: "6",
-      images: ["./prouducts_photo/Laptops/HP Probook 450/1.png",
-        "./prouducts_photo/Laptops/HP Probook 450/2.png",
-        "./prouducts_photo/Laptops/HP Probook 450/3.png",
-        "./prouducts_photo/Laptops/HP Probook 450/4.png",
-        "./prouducts_photo/Laptops/HP Probook 450/5.png"],
-      stars: 3.5,
-    },
-    {
-      type: "laptop",
-      description: "Details\n\
-                        Lenovo Legion 5 Pron\n\
-                        Core I7 12700H \n\
-                        32G Ram \n\
-                        1TB SSD\n\
-                        NVME -VGA Nvidia 6G\n\
-                        RTX 3060 -16.0\n\
-                        WQXGA 165Hz DOS\n\
-                        Color Gery = >>  EGP 78,390.00",
-      model: "Lenovo Legion 5 Pro",
-      price: "$2,536",
-      stock: "9",
-      images: ["./prouducts_photo/Laptops/Lenovo Legion 5 Pro/1.png",
-        "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/2.png",
-        "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/3.png",
-        "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/4.png",
-        "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/5.png"],
-      stars: "3.9",
-    }]
+  // const products = [{
+  //   type: "laptop",
+  //   description: "Details\n\
+  //                       Lenovo ThinkPad E14 Gen2\n\
+  //                       Intel Core i7-1165G7\n\
+  //                       512GB SSD\n\
+  //                       8GB Ram\n\
+  //                       Graphics NVIDIA GeForce MX450 2GB\n\
+  //                       Display 14 FHD (1920x1080) IPS 250nits\n\
+  //                       Color  black",
+  //   model: "Lenovo ThinkPad E14 Gen2",
+  //   price: "$1,375",
+  //   stock: "12",
+  //   images: ["./prouducts_photo/Laptops/LENOVO THINKPAD E14/1.png",
+  //     "./prouducts_photo/Laptops/LENOVO THINKPAD E14/2.png",
+  //     "./prouducts_photo/Laptops/LENOVO THINKPAD E14/3.png",
+  //     "./prouducts_photo/Laptops/LENOVO THINKPAD E14/4.png",
+  //     "./prouducts_photo/Laptops/LENOVO THINKPAD E14/5.png"],
+  //   stars: "4.8",
+  // },
+  //   {
+  //     type: "laptop",
+  //     description: "Details\n\
+  //                       Lenovo Ideapad Gaming 3\n\
+  //                       Core I7-12650H\n\
+  //                       16G Ram\n\
+  //                       512 NVME\n\
+  //                       VGA Nvidia 4G RTX 3050Ti\n\
+  //                       15.6 FHD 165Hz\n\
+  //                       Color gray",
+  //     model: "Lenovo Ideapad Gaming 3",
+  //     price: "$1,482",
+  //     stock: "5",
+  //     images: ["./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/1.png",
+  //       "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/2.png",
+  //       "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/3.png",
+  //       "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/4.png",
+  //       "./prouducts_photo/Laptops/Lenovo Ideapad Gaming 3/5.png"],
+  //     stars: "3",
+  //   },
+  //   {
+  //     type: "laptop",
+  //     description: "Details\n\
+  //                       HP Probook 450 G9\n\
+  //                       Core I5 - 1235U\n\
+  //                       15.6 HD\n\
+  //                       8GB\n\
+  //                       512GB SSD\n\
+  //                       MX570 2GB - DOS\n\
+  //                       color Silver Aluminum",
+  //     model: "HP Probook 450",
+  //     price: "$1,335",
+  //     stock: "6",
+  //     images: ["./prouducts_photo/Laptops/HP Probook 450/1.png",
+  //       "./prouducts_photo/Laptops/HP Probook 450/2.png",
+  //       "./prouducts_photo/Laptops/HP Probook 450/3.png",
+  //       "./prouducts_photo/Laptops/HP Probook 450/4.png",
+  //       "./prouducts_photo/Laptops/HP Probook 450/5.png"],
+  //     stars: 3.5,
+  //   },
+  //   {
+  //     type: "laptop",
+  //     description: "Details\n\
+  //                       Lenovo Legion 5 Pron\n\
+  //                       Core I7 12700H \n\
+  //                       32G Ram \n\
+  //                       1TB SSD\n\
+  //                       NVME -VGA Nvidia 6G\n\
+  //                       RTX 3060 -16.0\n\
+  //                       WQXGA 165Hz DOS\n\
+  //                       Color Gery = >>  EGP 78,390.00",
+  //     model: "Lenovo Legion 5 Pro",
+  //     price: "$2,536",
+  //     stock: "9",
+  //     images: ["./prouducts_photo/Laptops/Lenovo Legion 5 Pro/1.png",
+  //       "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/2.png",
+  //       "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/3.png",
+  //       "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/4.png",
+  //       "./prouducts_photo/Laptops/Lenovo Legion 5 Pro/5.png"],
+  //     stars: "3.9",
+  //   }]
   
   
   
@@ -106,8 +106,7 @@ const App = () => {
       <UserContext.Provider value={userLogin}>
         <Router>
         <Routes>
-          <Route path={ROUTES.LANDING} element={<><Header /><Home />    <Product Allproduct={products}></Product>
-</>}>
+          <Route path={ROUTES.LANDING} element={<><Header /><Home /></>}>
             <Route path={ROUTES.HOME} element={<><Header /><Home /></>} />
           </Route>
           

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -1,7 +1,7 @@
 import './index.css';
 import List from '../List/List';
 import { useContext, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+
 
 import {Link} from "react-router-dom";
 import Search from '../Search/Search';

--- a/frontend/src/components/Header/index.css
+++ b/frontend/src/components/Header/index.css
@@ -91,7 +91,7 @@ header .sign a {
   text-decoration: none;
 }
 
-header .sign input, header .sign .user {
+header .sign input, header .sign .user, header .sign a {
   border: 1px solid #fff;
   border-radius: 6px;
   font-weight: bold;
@@ -117,9 +117,9 @@ header .sign .user .MuiAvatar-icon {
   height: 10px
 }
 
-header .sign input:hover, header .sign .user a:hover {
+header .sign input:hover, header .sign a:hover {
   background-color: rgba(255, 255, 255, .3);
-  border: 1px solid #333;
+  
 }
 
 header .sign input, header .sign a {

--- a/frontend/src/components/Home/Home.jsx
+++ b/frontend/src/components/Home/Home.jsx
@@ -1,6 +1,34 @@
+import { useState, useEffect } from "react";
+import Product from "../Product/Product";
+import axios from "axios";
+import ErrorPage from "../ErrorPage/ErrorPage";
+
 const Home = () => {
+  // return <div>Home</div>
+  const [products, setProducts] = useState([]);
+
+  const getAllProducts = () => {
+    axios
+    .get('http://localhost:8000/vendorProduct') // This will be edit when the all products api is added
+    .then(res => {
+      console.log(res.data);
+      setProducts(res.data);
+      console.log(products);
+    })
+    .catch(error => {console.log(error)});
+  }
+
+  useEffect(() => {
+    getAllProducts();
+  }, []);
+
   return (
-    <div className="home"></div>
+    <>
+    <div className="home">
+      <Product Allproduct={products} IsVendor={false} />
+      {/* {products[0].images[0]} */}
+    </div>
+    </>
   );
 }
 

--- a/frontend/src/components/Home/index.css
+++ b/frontend/src/components/Home/index.css
@@ -1,0 +1,4 @@
+.home {
+  margin-top: 100px;
+  font-size: 40px;
+}

--- a/frontend/src/components/Product/Product.jsx
+++ b/frontend/src/components/Product/Product.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 import './index.css';
 import { useEffect } from 'react';
-import Item from "../Product/item";
+import Item from "../Product/Item";
 import VendorProduct from "../VendorProduct/VendorProduct";
 import AddItem from "../VendorProduct/AddItem";
 
@@ -23,7 +23,7 @@ const Product = (props) => {
     })
   })
 
-  // console.log(Allproduct)
+  console.log(Allproduct)
   return (
     <>
       <div id="product-container">

--- a/frontend/src/components/Product/item.jsx
+++ b/frontend/src/components/Product/item.jsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 
 
 
-const Product = (props) => {
+const Item = (props) => {
     const { product } = props;
     useEffect(() => {
         let heart_icon = document.querySelectorAll(".product-item .product-info i")
@@ -43,4 +43,4 @@ const Product = (props) => {
     );
 };
 
-export default Product;
+export default Item;

--- a/frontend/src/components/Vendor/Vendor.jsx
+++ b/frontend/src/components/Vendor/Vendor.jsx
@@ -115,7 +115,7 @@ const Vendor = () => {
   return (
     <>
       <div className='vendor'>
-        <Product Allproduct={vendorProducts} IsVendor="true"></Product>
+        <Product Allproduct={vendorProducts} IsVendor={true} />
       </div>
     </>
 


### PR DESCRIPTION
It will make the vendor products comes from api instead of the array.
It will show all products when the api is ready.
Note: I rename the file item.jsx because it should be Item.jsx, i.e. capital letter and make it export default Item instead of Product because that was a big problem that causes issues.